### PR TITLE
Accept signed int32 colors in validator

### DIFF
--- a/validate.ts
+++ b/validate.ts
@@ -8,6 +8,7 @@ import type { RenderOptions, RenderResult, Term } from "./term.ts";
 const u8 = Type.Integer({ minimum: 0, maximum: 255 });
 const u16 = Type.Integer({ minimum: 0, maximum: 65535 });
 const u32 = Type.Integer({ minimum: 0, maximum: 0xFFFFFFFF });
+const color = Type.Integer({ minimum: -0x80000000, maximum: 0xFFFFFFFF });
 
 /* ── Sizing axis (discriminated union) ────────────────────────────── */
 
@@ -64,7 +65,7 @@ const CornerRadius = Type.Object({
 });
 
 const Border = Type.Object({
-  color: u32,
+  color: color,
   left: Type.Optional(u8),
   right: Type.Optional(u8),
   top: Type.Optional(u8),
@@ -93,7 +94,7 @@ const OpenElement = Type.Object({
   id: Type.Literal(0x02),
   name: Type.String(),
   layout: Type.Optional(Layout),
-  bg: Type.Optional(u32),
+  bg: Type.Optional(color),
   cornerRadius: Type.Optional(CornerRadius),
   border: Type.Optional(Border),
   clip: Type.Optional(Clip),
@@ -103,7 +104,7 @@ const OpenElement = Type.Object({
 const TextOp = Type.Object({
   id: Type.Literal(0x03),
   content: Type.String(),
-  color: Type.Optional(u32),
+  color: Type.Optional(color),
   fontSize: Type.Optional(u8),
   fontId: Type.Optional(u8),
   wrap: Type.Optional(u8),

--- a/validate.ts
+++ b/validate.ts
@@ -7,8 +7,11 @@ import type { RenderOptions, RenderResult, Term } from "./term.ts";
 
 const u8 = Type.Integer({ minimum: 0, maximum: 255 });
 const u16 = Type.Integer({ minimum: 0, maximum: 65535 });
-const u32 = Type.Integer({ minimum: 0, maximum: 0xFFFFFFFF });
-const color = Type.Integer({ minimum: -0x80000000, maximum: 0xFFFFFFFF });
+
+/* RGBA color packed as (a << 24 | r << 16 | g << 8 | b). When alpha >= 128,
+ * bit 31 is set and JavaScript interprets the value as a negative int32.
+ * Accept both signed and unsigned representations of the same bit pattern. */
+const rgba = Type.Integer({ minimum: -0x80000000, maximum: 0xFFFFFFFF });
 
 /* ── Sizing axis (discriminated union) ────────────────────────────── */
 
@@ -65,7 +68,7 @@ const CornerRadius = Type.Object({
 });
 
 const Border = Type.Object({
-  color: color,
+  color: rgba,
   left: Type.Optional(u8),
   right: Type.Optional(u8),
   top: Type.Optional(u8),
@@ -94,7 +97,7 @@ const OpenElement = Type.Object({
   id: Type.Literal(0x02),
   name: Type.String(),
   layout: Type.Optional(Layout),
-  bg: Type.Optional(color),
+  bg: Type.Optional(rgba),
   cornerRadius: Type.Optional(CornerRadius),
   border: Type.Optional(Border),
   clip: Type.Optional(Clip),
@@ -104,7 +107,7 @@ const OpenElement = Type.Object({
 const TextOp = Type.Object({
   id: Type.Literal(0x03),
   content: Type.String(),
-  color: Type.Optional(color),
+  color: Type.Optional(rgba),
   fontSize: Type.Optional(u8),
   fontId: Type.Optional(u8),
   wrap: Type.Optional(u8),


### PR DESCRIPTION
## Motivation

The `rgba()` helper returns a signed int32 when alpha >= 128 (bit 31 is set via `(a & 0xFF) << 24`). JavaScript interprets this as a negative number. The validator's `u32` type (`minimum: 0`) rejects these values, causing `validated()` to throw on any color with full alpha — which is the default.

## Approach

Add a `color` type that accepts the full range from `-0x80000000` to `0xFFFFFFFF` and use it for `bg`, `border.color`, and text `color` fields. The underlying bit pattern is identical; the validator just needs to accept both signed and unsigned interpretations.

## Test plan

- [x] Existing validate tests pass
- [x] `validated()` accepts ops with `rgba(40, 42, 54)` (negative int32) without throwing