### PR TITLE
Inline WASM binary into generated TypeScript module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.agent-shell/
 /clayterm.wasm
+/wasm.ts
 /build/
 /node_modules/

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LDFLAGS = -Wl,--no-entry \
           -Wl,--undefined=Clay__MeasureText \
           -Wl,--undefined=Clay__QueryScrollOffset
 
-all: $(TARGET)
+all: $(TARGET) wasm.ts
 	@echo "Built $(TARGET) ($$(wc -c < $(TARGET)) bytes)"
 
 DEPS = $(wildcard src/*.c src/*.h)
@@ -21,7 +21,10 @@ DEPS = $(wildcard src/*.c src/*.h)
 $(TARGET): $(DEPS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(SRC)
 
+wasm.ts: $(TARGET)
+	deno run --allow-read --allow-write tasks/bundle-wasm.ts
+
 clean:
-	rm -f $(TARGET)
+	rm -f $(TARGET) wasm.ts
 
 .PHONY: all clean

--- a/deno.json
+++ b/deno.json
@@ -2,26 +2,28 @@
   "name": "@clayterm/clayterm",
   "license": "MIT",
   "tasks": {
-    "test": "deno test --allow-read",
+    "test": "deno test",
     "fmt": "deno fmt && clang-format -i src/*.c src/*.h",
     "fmt:check": "deno fmt --check && clang-format --dry-run --Werror src/*.c src/*.h",
     "build:npm": "deno run -A tasks/build-npm.ts",
     "build:jsr": "deno run -A tasks/build-jsr.ts",
-    "demo": "deno run -A demo/keyboard.ts"
+    "demo": "deno run demo/keyboard.ts"
   },
   "imports": {
     "@std/testing": "jsr:@std/testing@1",
     "@std/expect": "jsr:@std/expect@1",
     "@sinclair/typebox": "npm:@sinclair/typebox@^0.34",
     "dnt": "jsr:@deno/dnt@0.42.3",
-    "effection": "npm:effection@^4.0.2"
+    "effection": "npm:effection@^4.0.2",
+    "@std/encoding": "jsr:@std/encoding@1"
   },
   "exports": {
     ".": "./mod.ts",
     "./validate": "./validate.ts"
   },
   "publish": {
-    "include": ["*.ts", "clayterm.wasm"]
+    "include": ["*.ts"],
+    "exclude": ["!wasm.ts"]
   },
   "fmt": {
     "exclude": ["clay", "build"]

--- a/deno.lock
+++ b/deno.lock
@@ -8,6 +8,7 @@
     "jsr:@std/assert@^1.0.17": "1.0.18",
     "jsr:@std/async@^1.1.0": "1.1.1",
     "jsr:@std/data-structures@^1.0.10": "1.0.10",
+    "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/expect@1": "1.0.17",
     "jsr:@std/fmt@1": "1.0.8",
     "jsr:@std/fs@1": "1.0.22",
@@ -52,6 +53,9 @@
     },
     "@std/data-structures@1.0.10": {
       "integrity": "f574f86b0e07c69b9edc555fcc814b57d29258bad39fd5a34ba8a80ecf033cfe"
+    },
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
     "@std/expect@1.0.17": {
       "integrity": "316b47dd65c33e3151344eb3267bf42efba17d1415425f07ed96185d67fc04d9",
@@ -118,6 +122,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@deno/dnt@0.42.3",
+      "jsr:@std/encoding@1",
       "jsr:@std/expect@1",
       "jsr:@std/testing@1",
       "npm:@sinclair/typebox@0.34",

--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -44,4 +44,3 @@ await build({
 });
 
 await Deno.copyFile("README.md", `${outDir}/README.md`);
-await Deno.copyFile("clayterm.wasm", `${outDir}/esm/clayterm.wasm`);

--- a/tasks/bundle-wasm.ts
+++ b/tasks/bundle-wasm.ts
@@ -1,0 +1,13 @@
+import { encodeBase64 } from "@std/encoding/base64";
+
+const wasm = await Deno.readFile("clayterm.wasm");
+const base64 = encodeBase64(wasm);
+
+const source = `const bin = atob("${base64}");
+const bytes = new Uint8Array(bin.length);
+for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+export const compiled = await WebAssembly.compile(bytes);
+`;
+
+await Deno.writeTextFile("wasm.ts", source);
+console.log(`wrote wasm.ts (${wasm.length} bytes encoded)`);

--- a/wasm.ts
+++ b/wasm.ts
@@ -1,7 +1,0 @@
-import { readFile } from "node:fs/promises";
-
-const wasm = new Uint8Array(
-  await readFile(new URL("./clayterm.wasm", import.meta.url)),
-);
-
-export const compiled = await WebAssembly.compile(wasm);


### PR DESCRIPTION
## Summary

- Replace runtime filesystem read of `clayterm.wasm` with a build step that base64-encodes the binary into `wasm.ts`
- Eliminates `node:fs/promises` dependency and `--allow-read` permission requirement
- Fixes imports from non-`file://` URLs (esm.sh, `deno compile` binaries)

## Test plan

- [x] `make` builds WASM and generates `wasm.ts`
- [x] All 136 tests pass without `--allow-read` for the WASM file
- [x] `wasm.ts` is gitignored as a build artifact