### PR TITLE
Decouple alternate buffer switching from clearing

### DIFF
--- a/settings.ts
+++ b/settings.ts
@@ -19,9 +19,11 @@ export function settings(...sequence: Setting[]): Setting {
   };
 }
 
-export function alternateBuffer(): Setting {
+export function alternateBuffer(
+  options?: { clear?: boolean },
+): Setting {
   return {
-    apply: ALTSCREEN(),
+    apply: ALTSCREEN(options),
     revert: MAINSCREEN(),
   };
 }

--- a/termcodes.ts
+++ b/termcodes.ts
@@ -55,19 +55,27 @@ export function HIDECURSOR(): Uint8Array {
 }
 
 /**
- * Switch to the alternate screen buffer (xterm private mode 1049).
+ * Switch to the alternate screen buffer.
  *
- * Saves the cursor and switches to a clean alternate screen. Use
- * {@link MAINSCREEN} to switch back.
+ * Saves the cursor and switches to the alternate screen. When `clear` is
+ * `true` (the default), the alternate buffer is cleared on entry. When
+ * `false`, the existing contents are preserved.
+ *
+ * Use {@link MAINSCREEN} to switch back.
  *
  * @see {@link https://invisible-island.net/xterm/ctlseqs/ctlseqs.html | xterm control sequences}
  */
-export function ALTSCREEN(): Uint8Array {
-  return CSI("?1049h");
+export function ALTSCREEN(options?: { clear?: boolean }): Uint8Array {
+  let { clear = true } = options ?? {};
+  if (clear) {
+    return CSI("?1049h");
+  } else {
+    return CSI("?47h");
+  }
 }
 
 /**
- * Switch back to the main screen buffer (xterm private mode 1049).
+ * Switch back to the main screen buffer.
  *
  * Restores the cursor and returns to the main screen with scrollback intact.
  *

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -18,6 +18,12 @@ describe("settings", () => {
       expect(str(s.apply)).toBe("\x1b[?1049h");
       expect(str(s.revert)).toBe("\x1b[?1049l");
     });
+
+    it("uses mode 47 when clear is false", () => {
+      let s = alternateBuffer({ clear: false });
+      expect(str(s.apply)).toBe("\x1b[?47h");
+      expect(str(s.revert)).toBe("\x1b[?1049l");
+    });
   });
 
   describe("cursor", () => {


### PR DESCRIPTION
## Motivation

`alternateBuffer()` uses xterm private mode 1049, which clears the alternate buffer every time it is entered. This makes it impossible to toggle between main and alternate buffers without losing the alternate buffer's contents.

Closes #13

## Approach

Add a `{ clear?: boolean }` option to `ALTSCREEN()` in termcodes.ts. When `clear` is `false`, it emits mode 47 instead of 1049, which switches to the alternate buffer without clearing it. The option is threaded through `alternateBuffer()` in settings.ts. `MAINSCREEN()` always uses mode 1049 since the clear concern only applies on entry.