### PR TITLE
Add RenderInfo with lazy element bounds lookup

### DIFF
--- a/specs/renderer-spec.md
+++ b/specs/renderer-spec.md
@@ -631,7 +631,7 @@ prevent overlap.
 ### 12.3 Render return type
 
 The `render()` method currently returns a `RenderResult` object shaped as
-`{ output: Uint8Array, events: PointerEvent[] }`.
+`{ output: Uint8Array, events: PointerEvent[], info: RenderInfo }`.
 
 The `output` field is the ANSI byte output specified normatively in Section 7.3
 and Section 8.2.
@@ -642,6 +642,34 @@ a pointer-events feature implementation. The pointer event model is functional
 but has acknowledged gaps (no modifier keys on click events) and its interaction
 protocol (passing pointer state via render options, then reading events from the
 return value) was arrived at through iteration rather than upfront design.
+
+The `info` field implements `RenderInfo`, a read-only lookup keyed by element id
+(the `id` parameter passed to `open()`):
+
+```
+interface RenderInfo {
+  get(id: string): ElementInfo | undefined;
+}
+
+interface ElementInfo {
+  bounds: BoundingBox;
+}
+
+interface BoundingBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+```
+
+Each `ElementInfo` provides post-layout metadata. The `bounds` field is the
+element's computed bounding box in character cells, as determined by the layout
+engine after the render transaction completes. `x` and `y` are zero-indexed from
+the top-left corner of the layout root.
+
+Querying an element with an empty-string id or an id not present in the frame
+returns `undefined`.
 
 The return type of `render()` has changed twice since the project's inception
 (string, then `Uint8Array`, then `RenderResult`). While the ANSI bytes

--- a/src/clayterm.c
+++ b/src/clayterm.c
@@ -611,6 +611,20 @@ char *output(struct Clayterm *ct) { return ct->out.data; }
 
 int length(struct Clayterm *ct) { return ct->out.length; }
 
+int get_element_bounds(const char *name, int name_len, float *out) {
+  Clay_String str = {.length = name_len, .chars = name};
+  Clay_ElementId eid = Clay__HashString(str, 0);
+  Clay_ElementData data = Clay_GetElementData(eid);
+  if (!data.found) {
+    return 0;
+  }
+  out[0] = data.boundingBox.x;
+  out[1] = data.boundingBox.y;
+  out[2] = data.boundingBox.width;
+  out[3] = data.boundingBox.height;
+  return 1;
+}
+
 int pointer_over_count(void) { return Clay_GetPointerOverIds().length; }
 
 int pointer_over_id_string_length(int index) {

--- a/src/clayterm.h
+++ b/src/clayterm.h
@@ -17,6 +17,8 @@ char *output(struct Clayterm *ct);
 int length(struct Clayterm *ct);
 void measure(int ret, int txt);
 
+int get_element_bounds(const char *name, int name_len, float *out);
+
 int pointer_over_count(void);
 int pointer_over_id_string_length(int index);
 int pointer_over_id_string_ptr(int index);

--- a/term-native.ts
+++ b/term-native.ts
@@ -1,3 +1,21 @@
+import { f32, offsets, struct } from "./typedef.ts";
+
+export interface BoundingBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const BoundingBoxStruct = struct<BoundingBox>({
+  x: f32(),
+  y: f32(),
+  width: f32(),
+  height: f32(),
+});
+
+const BOUNDING_BOX = offsets(BoundingBoxStruct);
+
 export interface Native {
   memory: WebAssembly.Memory;
   statePtr: number;
@@ -7,6 +25,7 @@ export interface Native {
   length(ct: number): number;
   setPointer(x: number, y: number, down: boolean): void;
   getPointerOverIds(): string[];
+  getElementBounds(id: string): BoundingBox | undefined;
 }
 
 import { compiled } from "./wasm.ts";
@@ -60,6 +79,7 @@ export async function createTermNative(
     pointer_over_count(): number;
     pointer_over_id_string_length(index: number): number;
     pointer_over_id_string_ptr(index: number): number;
+    get_element_bounds(name: number, len: number, out: number): number;
   };
 
   let heap = ct.__heap_base.value as number;
@@ -100,6 +120,23 @@ export async function createTermNative(
         ids.push(decoder.decode(new Uint8Array(memory.buffer, ptr, len)));
       }
       return ids;
+    },
+    getElementBounds(id: string): BoundingBox | undefined {
+      let enc = new TextEncoder();
+      let bytes = enc.encode(id);
+      new Uint8Array(memory.buffer).set(bytes, opsBuf);
+      let out = opsBuf + 256;
+      let found = ct.get_element_bounds(opsBuf, bytes.length, out);
+      if (!found) {
+        return undefined;
+      }
+      let view = new DataView(memory.buffer);
+      return {
+        x: view.getFloat32(out + BOUNDING_BOX.x, true),
+        y: view.getFloat32(out + BOUNDING_BOX.y, true),
+        width: view.getFloat32(out + BOUNDING_BOX.width, true),
+        height: view.getFloat32(out + BOUNDING_BOX.height, true),
+      };
     },
   };
 }

--- a/term.ts
+++ b/term.ts
@@ -1,5 +1,5 @@
 import { type Op, pack } from "./ops.ts";
-import { createTermNative } from "./term-native.ts";
+import { type BoundingBox, createTermNative } from "./term-native.ts";
 
 export interface TermOptions {
   height: number;
@@ -32,9 +32,20 @@ export type PointerEvent =
   | { type: "pointerleave"; id: string }
   | { type: "pointerclick"; id: string };
 
+export type { BoundingBox };
+
+export interface ElementInfo {
+  bounds: BoundingBox;
+}
+
+export interface RenderInfo {
+  get(id: string): ElementInfo | undefined;
+}
+
 export interface RenderResult {
   output: Uint8Array;
   events: PointerEvent[];
+  info: RenderInfo;
 }
 
 export interface Term {
@@ -103,7 +114,17 @@ export async function createTerm(options: TermOptions): Promise<Term> {
       prev = current;
       wasDown = down;
 
-      return { output, events };
+      let info: RenderInfo = {
+        get(id: string): ElementInfo | undefined {
+          let bounds = native.getElementBounds(id);
+          if (bounds) {
+            return { bounds };
+          }
+          return undefined;
+        },
+      };
+
+      return { output, events, info };
     },
   };
 }

--- a/test/term.test.ts
+++ b/test/term.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "./suite.ts";
 import { createTerm, type Term } from "../term.ts";
-import { close, grow, open, rgba, text } from "../ops.ts";
+import { close, fixed, grow, open, rgba, text } from "../ops.ts";
 import { print } from "./print.ts";
 
 const decode = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
@@ -148,6 +148,46 @@ describe("term", () => {
 └──────────────────┘`.trim());
 
       expect(second.length).toBeLessThan(first.length);
+    });
+  });
+
+  describe("info", () => {
+    it("returns bounds for named elements", async () => {
+      let term = await createTerm({ width: 40, height: 10 });
+      let result = term.render([
+        open("root", {
+          layout: { width: grow(), height: grow(), direction: "ttb" },
+        }),
+        open("child", {
+          layout: { width: fixed(20), height: fixed(5) },
+        }),
+        close(),
+        close(),
+      ]);
+
+      let root = result.info.get("root");
+      expect(root).toBeDefined();
+      expect(root!.bounds).toEqual({ x: 0, y: 0, width: 40, height: 10 });
+
+      let child = result.info.get("child");
+      expect(child).toBeDefined();
+      expect(child!.bounds).toEqual({ x: 0, y: 0, width: 20, height: 5 });
+    });
+
+    it("returns undefined for unknown ids", async () => {
+      let term = await createTerm({ width: 20, height: 5 });
+      term.render([
+        open("root", { layout: { width: grow(), height: grow() } }),
+        close(),
+      ]);
+
+      let result = term.render([
+        open("root", { layout: { width: grow(), height: grow() } }),
+        close(),
+      ]);
+
+      expect(result.info.get("nonexistent")).toBeUndefined();
+      expect(result.info.get("")).toBeUndefined();
     });
   });
 

--- a/typedef.ts
+++ b/typedef.ts
@@ -56,6 +56,11 @@ export function array<T>(element: TypeDef<T>, length: number): Arr<T[]> {
   };
 }
 
+export const f32 = (): TypeDef<number> => ({
+  type: "f32",
+  byteLength: 4,
+  byteAlign: 4,
+});
 export const int32 = (): TypeDef<number> => ({
   type: "int32",
   byteLength: 4,


### PR DESCRIPTION
## Motivation

Higher-level frameworks need access to computed element bounding boxes after layout — for scroll containers, floating tooltips, or dirty-region tracking. Element IDs are now stable (hashed with seed 0), so callers can look up any element by id after rendering.

## Approach

Adds a single WASM export `get_element_bounds(name, len, out)` that hashes the id string, calls `Clay_GetElementData()`, and writes the bounding box to a float buffer. No tables, no globals — one function handles the lookup.

On the TypeScript side, `RenderResult` gains an `info: RenderInfo` field with a lazy `get(id)` method that calls into WASM on demand:

```typescript
interface RenderInfo {
  get(id: string): ElementInfo | undefined;
}

interface ElementInfo {
  bounds: BoundingBox;
}

interface BoundingBox {
  x: number;
  y: number;
  width: number;
  height: number;
}
```

Querying an unknown or empty-string id returns `undefined`.

### Alternate Designs

Earlier iterations materialized the full map eagerly using global tables and seven accessor functions. The lazy approach is simpler — one WASM export, no state, callers only pay for what they query.