### PR TITLE
📄 Add MIT license

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,11 @@
 - Each test file tests exactly one spec. Do not put tests for one spec into
   another spec's test file.
 
+## Commit and PR conventions
+
+Do not include any agent marketing material (e.g. "Generated with...",
+"Co-Authored-By: \<agent>") in commits, pull requests, issues, or comments.
+
 ## Rendering invariants
 
 - The renderer MUST NOT perform IO. It produces bytes; the caller writes them.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright 2025-2026 The Frontside Software, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Motivation

The project declares `"license": "MIT"` in `deno.json` but has no LICENSE file in the repository. This makes the licensing ambiguous for contributors and consumers.

## Approach

Add a standard MIT LICENSE file with copyright assigned to The Frontside Software, Inc (2025-2026), matching the convention used across other Frontside projects like effectionx.