### PR TITLE
🐛 add memmove shim for wasm builds

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -10,6 +10,27 @@ void *memcpy(void *dst, const void *src, size_t n) {
   return dst;
 }
 
+void *memmove(void *dst, const void *src, size_t n) {
+  unsigned char *d = (unsigned char *)dst;
+  const unsigned char *s = (const unsigned char *)src;
+
+  if (d == s || n == 0) {
+    return dst;
+  }
+
+  if (d < s) {
+    while (n--)
+      *d++ = *s++;
+  } else {
+    d += n;
+    s += n;
+    while (n--)
+      *--d = *--s;
+  }
+
+  return dst;
+}
+
 void *memset(void *dst, int c, size_t n) {
   unsigned char *d = (unsigned char *)dst;
   while (n--)

--- a/src/mem.h
+++ b/src/mem.h
@@ -6,6 +6,7 @@
 typedef __SIZE_TYPE__ size_t;
 
 void *memcpy(void *dst, const void *src, size_t n);
+void *memmove(void *dst, const void *src, size_t n);
 void *memset(void *dst, int c, size_t n);
 size_t strlen(const char *s);
 int align8(int n);


### PR DESCRIPTION
## Summary
- add a freestanding memmove shim for wasm32 builds
- declare memmove alongside the existing memcpy/memset shims
- fixes CI linker failures where clang emits calls to memmove under -nostdlib

## Validation
- make CC=/opt/homebrew/opt/llvm/bin/clang
- deno test