### PR TITLE
🧼 split layout and input entrypoints

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,9 @@ jobs:
         with:
           name: bench-build
           retention-days: 1
-          path: wasm.ts
+          path: |
+            layout.wasm.ts
+            input.wasm.ts
 
   benchmarks:
     name: Run benchmarks (walltime)

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -48,8 +48,10 @@ jobs:
         with:
           name: clayterm-wasm
           path: |
-            clayterm.wasm
-            wasm.ts
+            layout.wasm
+            input.wasm
+            layout.wasm.ts
+            input.wasm.ts
 
   test-alt-os:
     needs: test

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /.agent-shell/
-/clayterm-layout.wasm
-/clayterm-input.wasm
-/wasm-layout.ts
-/wasm-input.ts
+/layout.wasm
+/input.wasm
+/layout.wasm.ts
+/input.wasm.ts
 /build/
 /node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /.agent-shell/
-/clayterm.wasm
-/wasm.ts
+/clayterm-layout.wasm
+/clayterm-input.wasm
+/wasm-layout.ts
+/wasm-input.ts
 /build/
 /node_modules/

--- a/BUILD.md
+++ b/BUILD.md
@@ -18,10 +18,12 @@ The local source build is driven by `make`.
 
 It generates:
 
-- `clayterm.wasm` — the compiled WebAssembly module built from the C sources
-- `wasm.ts` — a generated TypeScript file derived from `clayterm.wasm`
+- `layout.wasm` — the layout WebAssembly module built from the C sources
+- `input.wasm` — the input WebAssembly module built from the C sources
+- `layout.wasm.ts` — generated TypeScript derived from `layout.wasm`
+- `input.wasm.ts` — generated TypeScript derived from `input.wasm`
 
-`wasm.ts` is generated output, not hand-maintained source.
+These `.ts` files are generated output, not hand-maintained source.
 
 ## Clone the repo with submodules
 
@@ -184,8 +186,10 @@ make
 
 This should produce:
 
-- `clayterm.wasm`
-- `wasm.ts`
+- `layout.wasm`
+- `input.wasm`
+- `layout.wasm.ts`
+- `input.wasm.ts`
 
 For a clean rebuild:
 
@@ -199,7 +203,7 @@ Re-run `make` when:
 
 - you change files under `src/`
 - you update the `clay` submodule
-- `clayterm.wasm` or `wasm.ts` is missing
+- `layout.wasm`, `input.wasm`, `layout.wasm.ts`, or `input.wasm.ts` is missing
 - generated outputs look stale after switching branches or pulling changes
 
 When in doubt, use a clean rebuild:
@@ -249,7 +253,7 @@ make clean && make
 Symptoms may include:
 
 - target-related `clang` errors mentioning `wasm32`
-- linker failures while producing `clayterm.wasm`
+- linker failures while producing the `.wasm` outputs
 
 Recovery:
 
@@ -270,8 +274,8 @@ If the smoke test fails, fix the toolchain first and only then rerun `make`.
 
 Symptoms may include:
 
-- `clayterm.wasm` is missing
-- `wasm.ts` is missing
+- `layout.wasm` or `input.wasm` is missing
+- `layout.wasm.ts` or `input.wasm.ts` is missing
 - you changed `src/` or updated `clay/`, but the generated outputs do not match
 
 Recovery:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS_BASE = --target=wasm32 -nostdlib \
               -mbulk-memory \
               -Isrc -I.
 
-INPUT_OPT  ?= -Oz
+INPUT_OPT  ?= -O2
 LAYOUT_OPT ?= -O2
 
 LAYOUT_CFLAGS = $(CFLAGS_BASE) $(LAYOUT_OPT) -DCLAY_IMPLEMENTATION -DCLAY_WASM

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 CC = clang
 
-CFLAGS = --target=wasm32 -nostdlib -O2 \
-         -ffunction-sections -fdata-sections \
-         -mbulk-memory \
-         -DCLAY_IMPLEMENTATION -DCLAY_WASM \
-         -Isrc -I.
+CFLAGS_BASE = --target=wasm32 -nostdlib \
+              -ffunction-sections -fdata-sections \
+              -mbulk-memory \
+              -Isrc -I.
+
+INPUT_OPT  ?= -Oz
+LAYOUT_OPT ?= -O2
+
+LAYOUT_CFLAGS = $(CFLAGS_BASE) $(LAYOUT_OPT) -DCLAY_IMPLEMENTATION -DCLAY_WASM
+INPUT_CFLAGS  = $(CFLAGS_BASE) $(INPUT_OPT)
 
 LDFLAGS_COMMON = -Wl,--no-entry \
                  -Wl,--import-memory \
@@ -55,10 +60,10 @@ all: layout.wasm input.wasm layout.wasm.ts input.wasm.ts
 	@echo "Built input.wasm  ($$(wc -c < input.wasm) bytes raw, $$(gzip -c input.wasm | wc -c) bytes gzip)"
 
 layout.wasm: $(DEPS)
-	$(CC) $(CFLAGS) $(LAYOUT_LDFLAGS) -o $@ src/module-layout.c
+	$(CC) $(LAYOUT_CFLAGS) $(LAYOUT_LDFLAGS) -o $@ src/module-layout.c
 
 input.wasm: $(DEPS)
-	$(CC) $(filter-out -DCLAY_IMPLEMENTATION -DCLAY_WASM, $(CFLAGS)) $(INPUT_LDFLAGS) -o $@ src/module-input.c
+	$(CC) $(INPUT_CFLAGS) $(INPUT_LDFLAGS) -o $@ src/module-input.c
 
 layout.wasm.ts: layout.wasm
 	deno run --allow-read --allow-write tasks/bundle-wasm.ts layout.wasm layout.wasm.ts

--- a/Makefile
+++ b/Makefile
@@ -50,23 +50,23 @@ INPUT_LDFLAGS = $(LDFLAGS_COMMON) \
 
 DEPS = $(wildcard src/*.c src/*.h)
 
-all: clayterm-layout.wasm clayterm-input.wasm wasm-layout.ts wasm-input.ts
-	@echo "Built clayterm-layout.wasm ($$(wc -c < clayterm-layout.wasm) bytes raw, $$(gzip -c clayterm-layout.wasm | wc -c) bytes gzip)"
-	@echo "Built clayterm-input.wasm  ($$(wc -c < clayterm-input.wasm) bytes raw, $$(gzip -c clayterm-input.wasm | wc -c) bytes gzip)"
+all: layout.wasm input.wasm layout.wasm.ts input.wasm.ts
+	@echo "Built layout.wasm ($$(wc -c < layout.wasm) bytes raw, $$(gzip -c layout.wasm | wc -c) bytes gzip)"
+	@echo "Built input.wasm  ($$(wc -c < input.wasm) bytes raw, $$(gzip -c input.wasm | wc -c) bytes gzip)"
 
-clayterm-layout.wasm: $(DEPS)
+layout.wasm: $(DEPS)
 	$(CC) $(CFLAGS) $(LAYOUT_LDFLAGS) -o $@ src/module-layout.c
 
-clayterm-input.wasm: $(DEPS)
+input.wasm: $(DEPS)
 	$(CC) $(filter-out -DCLAY_IMPLEMENTATION -DCLAY_WASM, $(CFLAGS)) $(INPUT_LDFLAGS) -o $@ src/module-input.c
 
-wasm-layout.ts: clayterm-layout.wasm
-	deno run --allow-read --allow-write tasks/bundle-wasm.ts clayterm-layout.wasm wasm-layout.ts
+layout.wasm.ts: layout.wasm
+	deno run --allow-read --allow-write tasks/bundle-wasm.ts layout.wasm layout.wasm.ts
 
-wasm-input.ts: clayterm-input.wasm
-	deno run --allow-read --allow-write tasks/bundle-wasm.ts clayterm-input.wasm wasm-input.ts
+input.wasm.ts: input.wasm
+	deno run --allow-read --allow-write tasks/bundle-wasm.ts input.wasm input.wasm.ts
 
 clean:
-	rm -f clayterm.wasm clayterm-layout.wasm clayterm-input.wasm wasm.ts wasm-layout.ts wasm-input.ts
+	rm -f layout.wasm input.wasm layout.wasm.ts input.wasm.ts
 
 .PHONY: all clean

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 CC = clang
-TARGET = clayterm.wasm
-SRC = src/module.c
 
 CFLAGS = --target=wasm32 -nostdlib -O2 \
          -ffunction-sections -fdata-sections \
@@ -8,7 +6,13 @@ CFLAGS = --target=wasm32 -nostdlib -O2 \
          -DCLAY_IMPLEMENTATION -DCLAY_WASM \
          -Isrc -I.
 
-EXPORTS = \
+LDFLAGS_COMMON = -Wl,--no-entry \
+                 -Wl,--import-memory \
+                 -Wl,--stack-first \
+                 -Wl,--strip-all \
+                 -Wl,--gc-sections
+
+LAYOUT_EXPORTS = \
   -Wl,--export=__heap_base \
   -Wl,--export=clayterm_size \
   -Wl,--export=init \
@@ -25,7 +29,10 @@ EXPORTS = \
   -Wl,--export=error_count \
   -Wl,--export=error_type \
   -Wl,--export=error_message_length \
-  -Wl,--export=error_message_ptr \
+  -Wl,--export=error_message_ptr
+
+INPUT_EXPORTS = \
+  -Wl,--export=__heap_base \
   -Wl,--export=input_size \
   -Wl,--export=input_init \
   -Wl,--export=input_scan \
@@ -33,27 +40,33 @@ EXPORTS = \
   -Wl,--export=input_event \
   -Wl,--export=input_delay
 
-LDFLAGS = -Wl,--no-entry \
-          -Wl,--import-memory \
-          -Wl,--stack-first \
-          -Wl,--strip-all \
-          -Wl,--gc-sections \
-          -Wl,--undefined=Clay__MeasureText \
-          -Wl,--undefined=Clay__QueryScrollOffset \
-          $(EXPORTS)
+LAYOUT_LDFLAGS = $(LDFLAGS_COMMON) \
+                 -Wl,--undefined=Clay__MeasureText \
+                 -Wl,--undefined=Clay__QueryScrollOffset \
+                 $(LAYOUT_EXPORTS)
 
-all: $(TARGET) wasm.ts
-	@echo "Built $(TARGET) ($$(wc -c < $(TARGET)) bytes raw, $$(gzip -c $(TARGET) | wc -c) bytes gzip)"
+INPUT_LDFLAGS = $(LDFLAGS_COMMON) \
+                $(INPUT_EXPORTS)
 
 DEPS = $(wildcard src/*.c src/*.h)
 
-$(TARGET): $(DEPS)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(SRC)
+all: clayterm-layout.wasm clayterm-input.wasm wasm-layout.ts wasm-input.ts
+	@echo "Built clayterm-layout.wasm ($$(wc -c < clayterm-layout.wasm) bytes raw, $$(gzip -c clayterm-layout.wasm | wc -c) bytes gzip)"
+	@echo "Built clayterm-input.wasm  ($$(wc -c < clayterm-input.wasm) bytes raw, $$(gzip -c clayterm-input.wasm | wc -c) bytes gzip)"
 
-wasm.ts: $(TARGET)
-	deno run --allow-read --allow-write tasks/bundle-wasm.ts
+clayterm-layout.wasm: $(DEPS)
+	$(CC) $(CFLAGS) $(LAYOUT_LDFLAGS) -o $@ src/module-layout.c
+
+clayterm-input.wasm: $(DEPS)
+	$(CC) $(filter-out -DCLAY_IMPLEMENTATION -DCLAY_WASM, $(CFLAGS)) $(INPUT_LDFLAGS) -o $@ src/module-input.c
+
+wasm-layout.ts: clayterm-layout.wasm
+	deno run --allow-read --allow-write tasks/bundle-wasm.ts clayterm-layout.wasm wasm-layout.ts
+
+wasm-input.ts: clayterm-input.wasm
+	deno run --allow-read --allow-write tasks/bundle-wasm.ts clayterm-input.wasm wasm-input.ts
 
 clean:
-	rm -f $(TARGET) wasm.ts
+	rm -f clayterm.wasm clayterm-layout.wasm clayterm-input.wasm wasm.ts wasm-layout.ts wasm-input.ts
 
 .PHONY: all clean

--- a/deno.json
+++ b/deno.json
@@ -20,6 +20,8 @@
   },
   "exports": {
     ".": "./mod.ts",
+    "./layout": "./layout.ts",
+    "./input": "./input.ts",
     "./validate": "./validate.ts"
   },
   "nodeModulesDir": "auto",

--- a/input-native.ts
+++ b/input-native.ts
@@ -169,7 +169,7 @@ export interface InputNative {
   delay(st: number): number;
 }
 
-import { compiled } from "./wasm-input.ts";
+import { compiled } from "./input.wasm.ts";
 
 export async function createInputNative(
   escLatency: number,

--- a/input-native.ts
+++ b/input-native.ts
@@ -169,7 +169,7 @@ export interface InputNative {
   delay(st: number): number;
 }
 
-import { compiled } from "./wasm.ts";
+import { compiled } from "./wasm-input.ts";
 
 export async function createInputNative(
   escLatency: number,
@@ -178,14 +178,6 @@ export async function createInputNative(
 
   let instance = await WebAssembly.instantiate(compiled, {
     env: { memory },
-    clay: {
-      measureTextFunction() {},
-      queryScrollOffsetFunction(ret: number) {
-        let v = new DataView(memory.buffer);
-        v.setFloat32(ret, 0, true);
-        v.setFloat32(ret + 4, 0, true);
-      },
-    },
   });
 
   let exports = instance.exports as unknown as {

--- a/layout.ts
+++ b/layout.ts
@@ -1,0 +1,4 @@
+export * from "./ops.ts";
+export * from "./term.ts";
+export * from "./settings.ts";
+export * from "./termcodes.ts";

--- a/src/module-input.c
+++ b/src/module-input.c
@@ -1,0 +1,6 @@
+/* module-input.c — input-only compilation unit, no Clay layout engine */
+
+#include "mem.c"
+#include "utf8.c"
+#include "trie.c"
+#include "input.c"

--- a/src/module-layout.c
+++ b/src/module-layout.c
@@ -1,0 +1,11 @@
+/* module-layout.c — layout-only compilation unit, no input parser */
+
+#include "../clay/clay.h"
+
+#include "mem.c"
+#include "buffer.c"
+#include "cell.c"
+#include "utf8.c"
+#include "wcwidth.c"
+#include "clayterm.c"
+#include "transitions.c"

--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -10,7 +10,12 @@ if (!version) {
 }
 
 await build({
-  entryPoints: ["./mod.ts"],
+  entryPoints: [
+    "./mod.ts",
+    { name: "./layout", path: "./layout.ts" },
+    { name: "./input", path: "./input.ts" },
+    { name: "./validate", path: "./validate.ts" },
+  ],
   outDir,
   shims: {
     deno: false,

--- a/tasks/bundle-wasm.ts
+++ b/tasks/bundle-wasm.ts
@@ -27,7 +27,9 @@ function encodeZ85(data: Uint8Array): string {
   return out.join("");
 }
 
-const wasm = await Deno.readFile("clayterm.wasm");
+const [input = "clayterm.wasm", output = "wasm.ts"] = Deno.args;
+
+const wasm = await Deno.readFile(input);
 
 const compressed = new Uint8Array(
   brotliCompressSync(wasm, {
@@ -50,9 +52,9 @@ const compressed=d(${JSON.stringify(z85)},${compressed.byteLength});
 export const compiled=await WebAssembly.compile(new Uint8Array(brotliDecompressSync(compressed)));
 `;
 
-await Deno.writeTextFile("wasm.ts", source);
+await Deno.writeTextFile(output, source);
 console.log(
-  `wrote wasm.ts (${wasm.length} → ${compressed.byteLength} bytes compressed, ${z85.length} bytes z85, ${
+  `wrote ${output} (${wasm.length} → ${compressed.byteLength} bytes compressed, ${z85.length} bytes z85, ${
     Math.round(z85.length / wasm.length * 100)
   }%)`,
 );

--- a/tasks/bundle-wasm.ts
+++ b/tasks/bundle-wasm.ts
@@ -27,7 +27,11 @@ function encodeZ85(data: Uint8Array): string {
   return out.join("");
 }
 
-const [input = "clayterm.wasm", output = "wasm.ts"] = Deno.args;
+const [input, output] = Deno.args;
+if (!input || !output) {
+  console.error("Usage: bundle-wasm.ts <input.wasm> <output.ts>");
+  Deno.exit(1);
+}
 
 const wasm = await Deno.readFile(input);
 

--- a/tasks/bundle-wasm.ts
+++ b/tasks/bundle-wasm.ts
@@ -47,13 +47,10 @@ const compressed = new Uint8Array(
 
 const z85 = encodeZ85(compressed);
 
-// Decoder uses division instead of >>> to avoid 32-bit truncation on values near 0xFFFFFFFF.
-const source = `import{brotliDecompressSync}from"node:zlib";
-const Z="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
-const T=new Uint8Array(128);for(let i=0;i<85;i++)T[Z.charCodeAt(i)]=i;
-function d(s:string,n:number){const b=new Uint8Array(n);let o=0;for(let i=0;i<s.length&&o<n;i+=5){const v=T[s.charCodeAt(i)]*52200625+T[s.charCodeAt(i+1)]*614125+T[s.charCodeAt(i+2)]*7225+T[s.charCodeAt(i+3)]*85+T[s.charCodeAt(i+4)];if(o<n)b[o++]=Math.floor(v/16777216);if(o<n)b[o++]=Math.floor(v/65536)%256;if(o<n)b[o++]=Math.floor(v/256)%256;if(o<n)b[o++]=v%256;}return b;}
-const compressed=d(${JSON.stringify(z85)},${compressed.byteLength});
-export const compiled=await WebAssembly.compile(new Uint8Array(brotliDecompressSync(compressed)));
+// args separated to keep deno fmt happy
+const args = `${JSON.stringify(z85)}, ${compressed.byteLength}`;
+const source = `import { decode } from "./wasm-decode.ts";
+export const compiled = await decode(${args});
 `;
 
 await Deno.writeTextFile(output, source);

--- a/term-native.ts
+++ b/term-native.ts
@@ -48,7 +48,7 @@ export interface Native {
   errorMessage(ct: number, index: number): string;
 }
 
-import { compiled } from "./wasm.ts";
+import { compiled } from "./wasm-layout.ts";
 
 export async function createTermNative(
   w: number,

--- a/term-native.ts
+++ b/term-native.ts
@@ -48,7 +48,7 @@ export interface Native {
   errorMessage(ct: number, index: number): string;
 }
 
-import { compiled } from "./wasm-layout.ts";
+import { compiled } from "./layout.wasm.ts";
 
 export async function createTermNative(
   w: number,

--- a/wasm-decode.ts
+++ b/wasm-decode.ts
@@ -1,0 +1,39 @@
+import { brotliDecompressSync } from "node:zlib";
+
+const Z85 =
+  "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
+
+const DECODE = new Uint8Array(128);
+for (let i = 0; i < 85; i++) DECODE[Z85.charCodeAt(i)] = i;
+
+// Division instead of >>> avoids 32-bit truncation on values near 0xFFFFFFFF.
+function decodeZ85(s: string, n: number): Uint8Array {
+  let bytes = new Uint8Array(n);
+  let o = 0;
+  for (let i = 0; i < s.length && o < n; i += 5) {
+    let v = DECODE[s.charCodeAt(i)] * 52200625 +
+      DECODE[s.charCodeAt(i + 1)] * 614125 +
+      DECODE[s.charCodeAt(i + 2)] * 7225 +
+      DECODE[s.charCodeAt(i + 3)] * 85 +
+      DECODE[s.charCodeAt(i + 4)];
+    if (o < n) bytes[o++] = Math.floor(v / 16777216);
+    if (o < n) bytes[o++] = Math.floor(v / 65536) % 256;
+    if (o < n) bytes[o++] = Math.floor(v / 256) % 256;
+    if (o < n) bytes[o++] = v % 256;
+  }
+  return bytes;
+}
+
+/**
+ * Decode an inlined WASM blob: z85 → brotli-decompress → compile.
+ *
+ * `byteLength` is the brotli-compressed length, used to size the z85
+ * decode buffer before decompression restores the original module.
+ */
+export function decode(
+  z85: string,
+  byteLength: number,
+): Promise<WebAssembly.Module> {
+  let compressed = decodeZ85(z85, byteLength);
+  return WebAssembly.compile(new Uint8Array(brotliDecompressSync(compressed)));
+}


### PR DESCRIPTION
Building on #50 (brotli+z85 encoding), this PR splits the WASM compilation into two scoped modules and exposes them as separate export subpaths, enabling **per-consumer dead-code elimination** and **per-module opt tuning**.

- WASM compilation now based on two scoped modules: `module-layout.c` and `module-input.c`
- new `./layout` and `./input` export subpaths exposed via `build-npm.ts`, allows downstream bundlers to tree-shake
- removed unified `wasm.ts`; updated `.gitignore` and `Makefile` clean targets accordingly

### Per-consumer DCE

Consumer that import only one subpath no longer need to load the other module's WASM.

| consumer | unified (`main`) | split | Δ |
| --- | --- | --- | --- |
| `clayterm/input` | 43.0 kB | **3.7 kB** | **−91%** |
| `clayterm/layout` | 43.0 kB | 39.2 kB | −9% |

Full bundle (JS + WASM), gzipped: input-only **47.8 kB → 8.5 kB (−82%)**; layout-only 48.8 kB → 45.4 kB (−7%).

### Honest size note

Now that brotli+z85 (#50) is on `main`, the split does **not** reduce total install size. `mem`/`utf8`/`wcwidth` are duplicated across both modules, so the combined WASM is ~equal (42.1 kB split vs 42.4 kB unified, brotli) and the full package is marginally larger (115.4 kB → 121.5 kB unpacked, +5.3%). The wins here are **scoping and per-module tunability**, not aggregate size. Narrower compilation units also let `--gc-sections` apply more aggressive DCE per module.
