### PR TITLE
chore: update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,4 +138,4 @@ jobs:
           STEPS_VARS_OUTPUTS_VERSION: ${{steps.vars.outputs.version}}
 
       - name: Publish JSR
-        run: deno publish --allow-dirty --token=${{ secrets.JSR_TOKEN }}
+        run: deno publish --allow-dirty

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,12 @@ jobs:
 
       - name: Get Version
         id: vars
-        run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^v//')
+        run: echo ::set-output name=version::$(echo "${GITHUB_REF_NAME}" | sed 's/^v//')
 
       - name: Build JSR
-        run: deno task build:jsr ${{steps.vars.outputs.version}}
+        run: deno task build:jsr "${STEPS_VARS_OUTPUTS_VERSION}"
+        env:
+          STEPS_VARS_OUTPUTS_VERSION: ${{steps.vars.outputs.version}}
 
       - name: dry run publish
         run: deno publish --dry-run --allow-dirty
@@ -55,7 +57,7 @@ jobs:
 
       - name: Get Version
         id: vars
-        run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^v//')
+        run: echo ::set-output name=version::$(echo "${GITHUB_REF_NAME}" | sed 's/^v//')
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -65,7 +67,9 @@ jobs:
           cache: ""
 
       - name: Build NPM
-        run: deno task build:npm ${{steps.vars.outputs.version}}
+        run: deno task build:npm "${STEPS_VARS_OUTPUTS_VERSION}"
+        env:
+          STEPS_VARS_OUTPUTS_VERSION: ${{steps.vars.outputs.version}}
 
       - name: dry run publish
         run: npm publish --dry-run --tag=verify
@@ -126,10 +130,12 @@ jobs:
 
       - name: Get Version
         id: vars
-        run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^v//')
+        run: echo ::set-output name=version::$(echo "${GITHUB_REF_NAME}" | sed 's/^v//')
 
       - name: Build JSR
-        run: deno task build:jsr ${{steps.vars.outputs.version}}
+        run: deno task build:jsr "${STEPS_VARS_OUTPUTS_VERSION}"
+        env:
+          STEPS_VARS_OUTPUTS_VERSION: ${{steps.vars.outputs.version}}
 
       - name: Publish JSR
         run: deno publish --allow-dirty --token=${{ secrets.JSR_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: setup deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
@@ -43,6 +44,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: setup deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
@@ -103,6 +105,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: setup deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          package-manager-cache: false
+          cache: ""
 
       - name: Build NPM
         run: deno task build:npm ${{steps.vars.outputs.version}}
@@ -87,6 +89,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          package-manager-cache: false
+          cache: ""
 
       - name: download build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   verify-jsr:
@@ -79,6 +78,9 @@ jobs:
   publish-npm:
     needs: [verify-jsr, verify-npm]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Setup Node
@@ -99,6 +101,9 @@ jobs:
   publish-jsr:
     needs: [verify-jsr, verify-npm]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
 
       - name: setup deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
 
@@ -40,12 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
 
       - name: setup deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
 
@@ -57,7 +57,7 @@ jobs:
         run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^v//')
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 
@@ -69,7 +69,7 @@ jobs:
         working-directory: ./build/npm
 
       - name: upload build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-build
           path: ./build/npm
@@ -80,12 +80,12 @@ jobs:
 
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 
       - name: download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: npm-build
           path: ./build/npm
@@ -100,12 +100,12 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
 
       - name: setup deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Get Version
         id: vars
-        run: echo ::set-output name=version::$(echo "${GITHUB_REF_NAME}" | sed 's/^v//')
+        run: echo "version=$(echo "${GITHUB_REF_NAME}" | sed 's/^v//')" >> $GITHUB_OUTPUT
 
       - name: Build JSR
         run: deno task build:jsr "${STEPS_VARS_OUTPUTS_VERSION}"
@@ -57,7 +57,7 @@ jobs:
 
       - name: Get Version
         id: vars
-        run: echo ::set-output name=version::$(echo "${GITHUB_REF_NAME}" | sed 's/^v//')
+        run: echo "version=$(echo "${GITHUB_REF_NAME}" | sed 's/^v//')" >> $GITHUB_OUTPUT
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -130,7 +130,7 @@ jobs:
 
       - name: Get Version
         id: vars
-        run: echo ::set-output name=version::$(echo "${GITHUB_REF_NAME}" | sed 's/^v//')
+        run: echo "version=$(echo "${GITHUB_REF_NAME}" | sed 's/^v//')" >> $GITHUB_OUTPUT
 
       - name: Build JSR
         run: deno task build:jsr "${STEPS_VARS_OUTPUTS_VERSION}"


### PR DESCRIPTION
Most of the changes here are the same as #40 and #39, and so I'm fairly confident it won't break. I'd suggest this is merged after those have been reviewed/merged for extra safety - as it is of course far more annoying if the release workflow breaks

For 603cec26bef8543ef2a57f04bad1b5a74af6cc9a it's important that OIDC is enabled in the publishing settings on JSR, and then also that the token is deleted (assuming that OIDC isn't already enabled and this is just old logic)