### PR TITLE
🏃 add input + combined startup benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,8 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # `workflow_dispatch` allows CodSpeed to trigger backtest
-  # performance analysis in order to generate initial data.
+  # `workflow_dispatch` allows CodSpeed to trigger
   workflow_dispatch:
 
 permissions: {}
@@ -67,7 +66,7 @@ jobs:
   simulation:
     name: Run benchmarks (simulation)
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: codspeed-macro
     permissions:
       contents: read # clone repo
       id-token: write # upload benchmark results to codspeed

--- a/bench/fixtures/create-both/mod.ts
+++ b/bench/fixtures/create-both/mod.ts
@@ -1,0 +1,7 @@
+import { createTerm } from "../../../term.ts";
+import { createInput } from "../../../input.ts";
+
+await Promise.all([
+  createTerm({ width: 80, height: 24 }),
+  createInput(),
+]);

--- a/bench/fixtures/create-input/mod.ts
+++ b/bench/fixtures/create-input/mod.ts
@@ -1,0 +1,3 @@
+import { createInput } from "../../../input.ts";
+
+await createInput();

--- a/bench/fixtures/render-and-input/mod.ts
+++ b/bench/fixtures/render-and-input/mod.ts
@@ -1,0 +1,17 @@
+import { createTerm } from "../../../term.ts";
+import { close, grow, open, text } from "../../../ops.ts";
+import { createInput } from "../../../input.ts";
+
+let [term, input] = await Promise.all([
+  createTerm({ width: 80, height: 24 }),
+  createInput(),
+]);
+
+term.render([
+  open("root", { layout: { width: grow(), height: grow(), direction: "ttb" } }),
+  text("Hello, World!"),
+  close(),
+]);
+
+// Up arrow (CSI A) — exercises the input parser path.
+input.scan(new Uint8Array([0x1b, 0x5b, 0x41]));

--- a/bench/startup.bench.ts
+++ b/bench/startup.bench.ts
@@ -6,7 +6,10 @@ let bench = withCodSpeed(new Bench({ name: "startup" }));
 
 bench
   .add("createTerm", () => spawnFixture("create-term"))
-  .add("time to first render", () => spawnFixture("render-minimal"));
+  .add("createInput", () => spawnFixture("create-input"))
+  .add("createTerm + createInput", () => spawnFixture("create-both"))
+  .add("time to first render", () => spawnFixture("render-minimal"))
+  .add("render + scan (both modules)", () => spawnFixture("render-and-input"));
 
 await bench.run();
 console.table(bench.table());


### PR DESCRIPTION
Follow-up to #52. Adds new startup benchmarks in [`mode: walltime`](https://codspeed.io/docs/instruments/walltime) to measure the full E2E perf of:
- `createInput` bootstrap
- combined `createTerm + createInput` bootstrap inside `Promise.all`
- `render + scan` hitting both modules

also sets both benchmark jobs to `codspeed-macro` runner to avoid hardware variance, which was causing quite a bit of noise