### PR TITLE
feat: size report CI

### DIFF
--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -83,15 +83,6 @@ jobs:
 
             if (deltaGzip === 0 && deltaRaw === 0) return;
 
-            const takeaway = deltaGzip < 0 ? 'Size Reduced' : 'Size Increased';
-
-            const body = [
-              '<!-- size-report -->',
-              `**${takeaway}** — ${fmtDelta(deltaGzip)} gz, ${fmtDelta(deltaRaw)} raw`,
-              '',
-              `${fmt(headTotal.gzip)} gz (${fmt(headTotal.raw)} raw)`,
-            ].join('\n');
-
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -99,6 +90,25 @@ jobs:
             });
 
             const existing = comments.find(c => c.body.startsWith('<!-- size-report -->'));
+
+            // Skip if the head sizes haven't changed since the last push
+            if (existing) {
+              const match = existing.body.match(/<!-- sizes:(.*?) -->/);
+              if (match) {
+                const prev = JSON.parse(match[1]);
+                if (prev.raw === headTotal.raw && prev.gzip === headTotal.gzip) return;
+              }
+            }
+
+            const takeaway = deltaGzip < 0 ? 'Size Reduced' : 'Size Increased';
+
+            const body = [
+              '<!-- size-report -->',
+              `<!-- sizes:${JSON.stringify(headTotal)} -->`,
+              `**${takeaway}** — ${fmtDelta(deltaGzip)} gz, ${fmtDelta(deltaRaw)} raw`,
+              '',
+              `${fmt(headTotal.gzip)} gz (${fmt(headTotal.raw)} raw)`,
+            ].join('\n');
 
             if (existing) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -81,10 +81,9 @@ jobs:
             const fmtDelta = (n) =>
               n === 0 ? '±0 KB' : `${n > 0 ? '+' : ''}${(n / 1024).toFixed(1)} KB`;
 
-            const takeaway =
-              deltaGzip < 0 ? 'Size Reduced' :
-              deltaGzip > 0 ? 'Size Increased' :
-              'No Change to Size';
+            if (deltaGzip === 0 && deltaRaw === 0) return;
+
+            const takeaway = deltaGzip < 0 ? 'Size Reduced' : 'Size Increased';
 
             const body = [
               '<!-- size-report -->',

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -67,21 +67,17 @@ jobs:
             const head = JSON.parse(fs.readFileSync('/tmp/head-sizes.json', 'utf8'));
             const base = JSON.parse(fs.readFileSync('/tmp/base-sizes.json', 'utf8'));
 
-            const total = (arr) => arr.reduce(
-              (acc, f) => ({ raw: acc.raw + f.raw, gzip: acc.gzip + f.gzip }),
-              { raw: 0, gzip: 0 }
-            );
+            const total = (arr) => arr.reduce((acc, f) => acc + f.size, 0);
             const headTotal = total(head);
             const baseTotal = total(base);
 
-            const deltaRaw = headTotal.raw - baseTotal.raw;
-            const deltaGzip = headTotal.gzip - baseTotal.gzip;
+            const delta = headTotal - baseTotal;
 
             const fmt = (n) => `${(n / 1024).toFixed(1)} KB`;
             const fmtDelta = (n) =>
-              n === 0 ? '±0 KB' : `${n > 0 ? '+' : ''}${(n / 1024).toFixed(1)} KB`;
+              `${n > 0 ? '+' : ''}${(n / 1024).toFixed(1)} KB`;
 
-            if (deltaGzip === 0 && deltaRaw === 0) return;
+            if (delta === 0) return;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -93,21 +89,18 @@ jobs:
 
             // Skip if the head sizes haven't changed since the last push
             if (existing) {
-              const match = existing.body.match(/<!-- sizes:(.*?) -->/);
-              if (match) {
-                const prev = JSON.parse(match[1]);
-                if (prev.raw === headTotal.raw && prev.gzip === headTotal.gzip) return;
-              }
+              const match = existing.body.match(/<!-- sizes:(\d+) -->/);
+              if (match && Number(match[1]) === headTotal) return;
             }
 
-            const takeaway = deltaGzip < 0 ? 'Size Reduced' : 'Size Increased';
+            const takeaway = delta < 0 ? 'Size Reduced' : 'Size Increased';
 
             const body = [
               '<!-- size-report -->',
-              `<!-- sizes:${JSON.stringify(headTotal)} -->`,
-              `**${takeaway}** — ${fmtDelta(deltaGzip)} gz, ${fmtDelta(deltaRaw)} raw`,
+              `<!-- sizes:${headTotal} -->`,
+              `**${takeaway}** — ${fmtDelta(delta)}`,
               '',
-              `${fmt(headTotal.gzip)} gz (${fmt(headTotal.raw)} raw)`,
+              `${fmt(headTotal)} unpacked`,
             ].join('\n');
 
             if (existing) {

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -1,0 +1,118 @@
+name: Size Report
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  size-report:
+    name: Size Report
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          submodules: true
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: setup deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.x
+
+      - name: setup node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
+        with:
+          node-version: 24
+
+      - name: build (head)
+        run: make && deno task build:npm 0.0.0
+
+      - name: measure sizes (head)
+        run: |
+          cp tasks/measure-size.ts /tmp/measure-size.ts
+          deno run --allow-read /tmp/measure-size.ts > /tmp/head-sizes.json
+
+      - name: find merge base
+        id: base
+        run: |
+          SHA=$(git merge-base HEAD origin/${{ github.base_ref }})
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+
+      - name: checkout base commit
+        run: |
+          git checkout ${{ steps.base.outputs.sha }}
+          git submodule update --init --recursive
+
+      - name: build (base)
+        run: make && deno task build:npm 0.0.0
+
+      - name: measure sizes (base)
+        run: deno run --allow-read /tmp/measure-size.ts > /tmp/base-sizes.json
+
+      - name: post size report
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const head = JSON.parse(fs.readFileSync('/tmp/head-sizes.json', 'utf8'));
+            const base = JSON.parse(fs.readFileSync('/tmp/base-sizes.json', 'utf8'));
+
+            const total = (arr) => arr.reduce(
+              (acc, f) => ({ raw: acc.raw + f.raw, gzip: acc.gzip + f.gzip }),
+              { raw: 0, gzip: 0 }
+            );
+            const headTotal = total(head);
+            const baseTotal = total(base);
+
+            const deltaRaw = headTotal.raw - baseTotal.raw;
+            const deltaGzip = headTotal.gzip - baseTotal.gzip;
+
+            const fmt = (n) => `${(n / 1024).toFixed(1)} KB`;
+            const fmtDelta = (n) =>
+              n === 0 ? '±0 KB' : `${n > 0 ? '+' : ''}${(n / 1024).toFixed(1)} KB`;
+
+            const takeaway =
+              deltaGzip < 0 ? 'Size Reduced' :
+              deltaGzip > 0 ? 'Size Increased' :
+              'No Change to Size';
+
+            const body = [
+              '<!-- size-report -->',
+              `**${takeaway}** — ${fmtDelta(deltaGzip)} gz, ${fmtDelta(deltaRaw)} raw`,
+              '',
+              `${fmt(headTotal.gzip)} gz (${fmt(headTotal.raw)} raw)`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.startsWith('<!-- size-report -->'));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/tasks/measure-size.ts
+++ b/tasks/measure-size.ts
@@ -5,8 +5,8 @@ const results: Array<{ file: string; raw: number; gzip: number }> = [];
 
 for await (const entry of Deno.readDir(dir)) {
   if (!entry.isFile) continue;
-  const path = `${dir}/${entry.name}`;
-  const data = await Deno.readFile(path);
+  let path = `${dir}/${entry.name}`;
+  let data = await Deno.readFile(path);
   results.push({
     file: entry.name,
     raw: data.byteLength,

--- a/tasks/measure-size.ts
+++ b/tasks/measure-size.ts
@@ -1,17 +1,11 @@
-import { gzipSync } from "node:zlib";
-
 const dir = "build/npm/esm";
-const results: Array<{ file: string; raw: number; gzip: number }> = [];
+const results: Array<{ file: string; size: number }> = [];
 
 for await (const entry of Deno.readDir(dir)) {
   if (!entry.isFile) continue;
   let path = `${dir}/${entry.name}`;
-  let data = await Deno.readFile(path);
-  results.push({
-    file: entry.name,
-    raw: data.byteLength,
-    gzip: gzipSync(data).byteLength,
-  });
+  let { size } = await Deno.stat(path);
+  results.push({ file: entry.name, size });
 }
 
 results.sort((a, b) => a.file.localeCompare(b.file));

--- a/tasks/measure-size.ts
+++ b/tasks/measure-size.ts
@@ -1,0 +1,18 @@
+import { gzipSync } from "node:zlib";
+
+const dir = "build/npm/esm";
+const results: Array<{ file: string; raw: number; gzip: number }> = [];
+
+for await (const entry of Deno.readDir(dir)) {
+  if (!entry.isFile) continue;
+  const path = `${dir}/${entry.name}`;
+  const data = await Deno.readFile(path);
+  results.push({
+    file: entry.name,
+    raw: data.byteLength,
+    gzip: gzipSync(data).byteLength,
+  });
+}
+
+results.sort((a, b) => a.file.localeCompare(b.file));
+console.log(JSON.stringify(results));


### PR DESCRIPTION
- Adds `tasks/measure-size.ts` — walks `build/npm/esm/`, outputs unpacked size per file as JSON
- Adds `.github/workflows/size-report.yml` — builds npm output for both PR head and merge-base commit, diffs totals, posts/updates a single PR comment

Comment format:
```
**Size Reduced** — -3.1 KB

193.0 KB unpacked
```

Only posts when size changes vs merge-base. Only updates when head sizes change between pushes.