### PR TITLE
fix(ci): rebuild from clean in size-report so build-config changes are measured

### DIFF
--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: 24
 
       - name: build (head)
-        run: make && deno task build:npm 0.0.0
+        run: make clean && make && deno task build:npm 0.0.0
 
       - name: measure sizes (head)
         run: |
@@ -54,7 +54,7 @@ jobs:
           git submodule update --init --recursive
 
       - name: build (base)
-        run: make && deno task build:npm 0.0.0
+        run: make clean && make && deno task build:npm 0.0.0
 
       - name: measure sizes (base)
         run: deno run --allow-read /tmp/measure-size.ts > /tmp/base-sizes.json


### PR DESCRIPTION
The size report builds head then base without cleaning in between. For PRs that change only build configuration (Makefile, `patches/`, compiler flags) and not `src/*.c`, `make` sees `clayterm.wasm` as newer than the unchanged sources and skips the base rebuild — so the base step re-measures the head artifact, the delta comes out 0, and no size comment is posted even though the wasm size actually changed.

- Run `make clean && make` for both the head and base builds so each is a from-scratch compile.
- Surfaced by #89 (compile out Clay's debug-tools UI, ≈ −14 KB unpacked): the reduction is real in CI but the report can't see it because that PR only touches `Makefile` / `patches/`. Once this lands and #89 re-runs, its size comment will populate.
