### PR TITLE
chore(docs): add lld mention for macOS to BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -162,7 +162,8 @@ clang --version
 deno --version
 ```
 
-For a quick wasm-target smoke test, make sure `clang` can compile and link for `wasm32`:
+For a quick wasm-target smoke test, make sure `clang` can compile and link for
+`wasm32`:
 
 ```sh
 clang --target=wasm32 -nostdlib -Wl,--no-entry -x c /dev/null -o /tmp/clayterm-wasm-test.wasm

--- a/BUILD.md
+++ b/BUILD.md
@@ -56,6 +56,7 @@ You need:
 - `git`
 - `make`
 - `clang` with wasm32-capable support
+- `lld` (provides `wasm-ld`)
 - `deno`
 
 Equivalent packages are fine if your package manager uses different names.
@@ -71,10 +72,10 @@ including `git` and `make`.
 xcode-select --install
 ```
 
-Then install LLVM and Deno with Homebrew:
+Then install LLVM, LLD, and Deno with Homebrew:
 
 ```sh
-brew install llvm deno
+brew install llvm lld deno
 ```
 
 Use Homebrew LLVM before Apple's system `clang` when building `@bomb.sh/tty`:
@@ -161,11 +162,11 @@ clang --version
 deno --version
 ```
 
-For a quick wasm-target smoke test, make sure `clang` can compile for `wasm32`:
+For a quick wasm-target smoke test, make sure `clang` can compile and link for `wasm32`:
 
 ```sh
-clang --target=wasm32 -c -x c /dev/null -o /tmp/clayterm-wasm-test.o
-rm -f /tmp/clayterm-wasm-test.o
+clang --target=wasm32 -nostdlib -Wl,--no-entry -x c /dev/null -o /tmp/clayterm-wasm-test.wasm
+rm -f /tmp/clayterm-wasm-test.wasm
 ```
 
 On macOS, if `which clang` still points to `/usr/bin/clang` and the wasm test
@@ -253,12 +254,13 @@ Recovery:
 
 - make sure you are using an LLVM/Clang build with wasm support
 - on macOS, prefer the Homebrew `llvm` toolchain over `/usr/bin/clang`
+- on macOS, install `lld`; it provides `wasm-ld`
 - on Linux/WSL2, make sure both `clang` and `lld` are installed
 - rerun the wasm smoke test:
 
 ```sh
-clang --target=wasm32 -c -x c /dev/null -o /tmp/clayterm-wasm-test.o
-rm -f /tmp/clayterm-wasm-test.o
+clang --target=wasm32 -nostdlib -Wl,--no-entry -x c /dev/null -o /tmp/clayterm-wasm-test.wasm
+rm -f /tmp/clayterm-wasm-test.wasm
 ```
 
 If the smoke test fails, fix the toolchain first and only then rerun `make`.


### PR DESCRIPTION
## What does this PR do?

<!--
  Describe the change and why it's needed. Link to a related issue or discussion.
  If there is no issue, please explain why one isn't needed.
-->

`BUILD.md` does not mention the `lld` requirement for macOS. Following the instructions means `make` fails even though the `clang` smoke test passes. `lld` is needed.

I couldn't find an existing issue. If you'd rather author your own changes to BUILD.md, feel free to close this - I just wanted to make a quick fix to a small issue available.

## Type of change

<!-- Check one. -->

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [X] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

These seem generic to other bombshell projects and don't apply here (`deno test` does pass).

- [ ] All tests pass (`pnpm test`)
- [ ] Files are formatted (`pnpm format`)
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [X] This PR includes AI-generated code

Opus 4.8 helped update the smoke test to also link and more closely match the commands used in `make` to catch other missing dependencies.
