### PR TITLE
🔧 ci: pin Deno to v2.8.3 to work around v2.9.0 JSR warm-cache regression

### DIFF
--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -27,7 +27,10 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
-          deno-version: v2.x
+          # Pinned to v2.8.3 to avoid https://github.com/denoland/deno/issues/35529
+          # (v2.9.0 rejects JSR files without a manifest checksum on warm cache).
+          # Restore to v2.x once v2.9.1 ships.
+          deno-version: v2.8.3
 
       - name: setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -29,7 +29,10 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
-          deno-version: v2.x
+          # Pinned to v2.8.3 to avoid https://github.com/denoland/deno/issues/35529
+          # (v2.9.0 rejects JSR files without a manifest checksum on warm cache).
+          # Restore to v2.x once v2.9.1 ships.
+          deno-version: v2.8.3
 
       - name: format
         run: deno task fmt:check
@@ -71,7 +74,10 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
-          deno-version: v2.x
+          # Pinned to v2.8.3 to avoid https://github.com/denoland/deno/issues/35529
+          # (v2.9.0 rejects JSR files without a manifest checksum on warm cache).
+          # Restore to v2.x once v2.9.1 ships.
+          deno-version: v2.8.3
 
       - name: download wasm artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -95,7 +101,10 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
-          deno-version: v2.x
+          # Pinned to v2.8.3 to avoid https://github.com/denoland/deno/issues/35529
+          # (v2.9.0 rejects JSR files without a manifest checksum on warm cache).
+          # Restore to v2.x once v2.9.1 ships.
+          deno-version: v2.8.3
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## What does this PR do?

Pins `deno-version` to `v2.8.3` in `size-report.yml` and `verify.yaml` (previously `v2.x`, which floats to v2.9.0).

Deno v2.9.0 has a regression [denoland/deno#35529][issue] where JSR files that have no manifest checksum (e.g. `@ts-morph/common@0.27.0`'s dynamic `require("./crypto")`, which resolves to a nonexistent file) pass on cold download but fail integrity check on warm cache:

    error: Integrity check failed in package.
      Specifier: https://jsr.io/@ts-morph/common/0.27.0/crypto
      Actual:   e3b0c442…  (sha256 of empty bytes)
      Expected: package-manifest-missing-checksum

The Size Report workflow builds twice on one runner (head, then base) sharing `~/.cache/deno`. The head build downloads fresh and passes; the base build hits the warm cache and errors — [example failing run][run]. Every Size Report run since 2026-06-30 has failed this way. Verify hasn't been bitten yet because it only builds once per runner, but I pinned it too so the next non-trivial refactor doesn't reintroduce a double build.

The upstream fix has been merged but no v2.9.1 tag exists yet. A comment in each workflow says to restore `v2.x` once it ships.

[issue]: https://github.com/denoland/deno/issues/35529
[run]: https://github.com/bombshell-dev/tty/actions/runs/28342218409/job/84486764209

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [ ] All tests pass (`pnpm test`) — CI verifies
- [x] Files are formatted (`pnpm format`)
- [ ] I have added/updated tests for my changes (if applicable) — n/a
- [ ] I have added a changeset — n/a, CI-only change

## AI-generated code disclosure

- [x] This PR includes AI-generated code