### PR TITLE
ref(opt): scale Clay's arena with the terminal grid

### DIFF
--- a/.changeset/grid-scaled-arena.md
+++ b/.changeset/grid-scaled-arena.md
@@ -1,0 +1,5 @@
+---
+'@bomb.sh/tty': patch
+---
+
+Scales the renderer's memory arena to the terminal grid instead of a fixed default, cutting the reservation for an 80×24 grid ~51% (4.85 MB → 2.39 MB) with no change to render performance.

--- a/src/clayterm.c
+++ b/src/clayterm.c
@@ -552,7 +552,24 @@ static Clay_SizingAxis decode_axis(uint32_t *buf, int len, int *i) {
 
 static int align64(int n) { return (n + 63) & ~63; }
 
+/* Clay's element capacity drives nearly all of Clay_MinMemorySize, so scale it
+ * with the grid instead of shipping Clay's fixed 8192-element default. 2x cells
+ * bounds sane trees (leaves >= 1 cell, branching >= 2); the ceiling preserves
+ * today's capacity for large grids, the floor keeps headroom on tiny ones.
+ * Must run before Clay_MinMemorySize in both clayterm_size and init so the
+ * size the host queries always matches the arena init consumes. */
+static void set_clay_capacity(int w, int h) {
+  int elems = w * h * 2;
+  if (elems < 2048)
+    elems = 2048;
+  if (elems > 8192)
+    elems = 8192;
+  Clay_SetMaxElementCount(elems);
+  Clay_SetMaxMeasureTextCacheWordCount(elems * 2);
+}
+
 int clayterm_size(int w, int h) {
+  set_clay_capacity(w, h);
   int cell_count = w * h;
   int cell_bytes = cell_count * (int)sizeof(Cell);
   int out_bytes = cell_count * OUT_BYTES_PER_CELL;
@@ -613,6 +630,7 @@ int error_message_ptr(struct Clayterm *ct, int index) {
 }
 
 struct Clayterm *init(void *mem, int w, int h) {
+  set_clay_capacity(w, h);
   struct Clayterm *ct = (struct Clayterm *)mem;
   int cell_count = w * h;
   int cell_bytes = align8(cell_count * (int)sizeof(Cell));


### PR DESCRIPTION
Clay reserves a fixed arena sized for 8192 elements regardless of terminal size, so an 80x24 pane holds 4.85 MB before drawing anything.

In this PR, we adjust the arena size to match an element cap derived from the grid size: 2x cells, clamped to [2048, 8192]. Every leaf takes at least one cell and internal nodes with 2+ children at most double the leaf count, so 2x cells bounds realistic trees with headroom for floating and wrapper chains. The ceiling preserves today's capacity on large grids; the floor protects tiny panes. 80x24 drops to 2.39 MB (-51%); 200x50 is unchanged; render benches are flat.

The cap is set at the top of both `clayterm_size()` and `init()` so the size the host queries always matches what init consumes. That's what lets this compose with #113 — a resize re-runs both and grows the arena correctly in either direction.