### PR TITLE
fix(ci): use git CLI for changeset version PR push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,5 +53,6 @@ jobs:
           commit-message: "chore: version packages"
           pr-title: "chore: version packages"
           create-github-releases: false
+          push-with-git-cli: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fast-follow to #118

Changeset's default GitHub path uses the `createTree` endpoint which doesn't support submodules, so `clay` causes `changesets/action` to fail when creating the "Version Packages" PR branch

Setting `push-with-git-cli: true` bypasses the API and uses native `git push`