### PR TITLE
ci(benchmark): only run for source-affecting changes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,31 +6,31 @@ on:
     # Benchmark inputs: C source, TS source, benchmarks, and build config.
     # Docs-only and CI-only changes skip the workflow entirely.
     paths:
-      - 'src/**'
-      - 'clay' # submodule pointer
-      - 'patches/**'
-      - 'Makefile'
-      - '*.ts'
-      - 'bench/**'
-      - 'tasks/**'
-      - 'deno.json'
-      - 'deno.lock'
-      - 'package.json'
-      - 'package-lock.json'
+      - "src/**"
+      - "clay" # submodule pointer
+      - "patches/**"
+      - "Makefile"
+      - "*.ts"
+      - "bench/**"
+      - "tasks/**"
+      - "deno.json"
+      - "deno.lock"
+      - "package.json"
+      - "package-lock.json"
   pull_request:
     branches: [main]
     paths:
-      - 'src/**'
-      - 'clay' # submodule pointer
-      - 'patches/**'
-      - 'Makefile'
-      - '*.ts'
-      - 'bench/**'
-      - 'tasks/**'
-      - 'deno.json'
-      - 'deno.lock'
-      - 'package.json'
-      - 'package-lock.json'
+      - "src/**"
+      - "clay" # submodule pointer
+      - "patches/**"
+      - "Makefile"
+      - "*.ts"
+      - "bench/**"
+      - "tasks/**"
+      - "deno.json"
+      - "deno.lock"
+      - "package.json"
+      - "package-lock.json"
   # `workflow_dispatch` allows CodSpeed to trigger
   workflow_dispatch:
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,8 +3,34 @@ name: Benchmark
 on:
   push:
     branches: [main]
+    # Benchmark inputs: C source, TS source, benchmarks, and build config.
+    # Docs-only and CI-only changes skip the workflow entirely.
+    paths:
+      - 'src/**'
+      - 'clay' # submodule pointer
+      - 'patches/**'
+      - 'Makefile'
+      - '*.ts'
+      - 'bench/**'
+      - 'tasks/**'
+      - 'deno.json'
+      - 'deno.lock'
+      - 'package.json'
+      - 'package-lock.json'
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'clay' # submodule pointer
+      - 'patches/**'
+      - 'Makefile'
+      - '*.ts'
+      - 'bench/**'
+      - 'tasks/**'
+      - 'deno.json'
+      - 'deno.lock'
+      - 'package.json'
+      - 'package-lock.json'
   # `workflow_dispatch` allows CodSpeed to trigger
   workflow_dispatch:
 


### PR DESCRIPTION
CI benchmarks are currently triggered on every PR.

This PR adds specific path filters to our workflows so that docs/CI-only changes skip the benchmarks and build. Direct source code changes, dependency updates, and tooling changes still run. 